### PR TITLE
Now ignores empty strings when field is not required.

### DIFF
--- a/fields/field.time.php
+++ b/fields/field.time.php
@@ -86,11 +86,13 @@
 		}
 
 		function displayPublishPanel(&$wrapper, $data=NULL, $flagWithError=NULL, $fieldnamePrefix=NULL, $fieldnamePostfix=NULL){
-			$value = (int)$data['seconds'];
+				$value = (int)$data['seconds'];
 
 			$label = Widget::Label($this->get('label'));
 			if($this->get('required') != 'yes') $label->appendChild(new XMLElement('i', 'Optional'));
-			$label->appendChild(Widget::Input('fields'.$fieldnamePrefix.'['.$this->get('element_name').']'.$fieldnamePostfix, self::timeIntToString($value)));
+			$label->appendChild(Widget::Input('fields'.$fieldnamePrefix.'['.$this->get('element_name').']'.$fieldnamePostfix, (strlen($data['value']) != 0 ? self::timeIntToString($value) : NULL)));
+
+
 
 			if($flagWithError != NULL) $wrapper->appendChild(Widget::wrapFormElementWithError($label, $flagWithError));
 			else $wrapper->appendChild($label);


### PR DESCRIPTION
Events were throwing the `Time must be entered in the format <code>HH:MM:SS</code>` error when the field was empty even though it is not required.

(Second commit keeps the field blank when the form input is left blank instead of saving 00:00:00 in the entry.
